### PR TITLE
move configuration files to $XDG_CONFIG_HOME

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -19,6 +19,7 @@ import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 
+from appdirs import user_config_dir
 import os.path
 import pickle
 
@@ -33,7 +34,7 @@ class Settings(Observable):
 
         self.gtksettings = Gtk.Settings.get_default()
         
-        self.pathname = os.path.expanduser('~') + '/.porto'
+        self.pathname = user_config_dir("porto")
         
         self.data = dict()
         self.defaults = dict()

--- a/workspace/recently_opened_notebooks_list/recently_opened_notebooks_list.py
+++ b/workspace/recently_opened_notebooks_list/recently_opened_notebooks_list.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>
 
+from appdirs import user_config_dir
 import pickle
 import os.path
 
@@ -29,7 +30,7 @@ class RecentlyOpenedNotebooksList(Observable):
         Observable.__init__(self)
 
         self.workspace = workspace
-        self.pathname = os.path.expanduser('~') + '/.porto'
+        self.pathname = user_config_dir("porto")
         self.items = dict()
 
         self.presenter = ro_presenter.RecentlyOpenedNotebooksListPresenter(workspace, self)


### PR DESCRIPTION
This PR changes the location of config files from `~/.porto` to `$XDG_CONFIG_HOME/porto` (usually `~/.config/porto).

Tested on Linux.


Closes #10 